### PR TITLE
Fix url for pyshorteners

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
                         <span class="title">Sharer.js</span>
                         <span class="description">Create your own social share buttons</span>
                     </a>
-                    <a class="project" target="_blank" href="http://ellisonleao.github.io/pyshorteners/">
+                    <a class="project" target="_blank" href="https://github.com/ellisonleao/pyshorteners">
                         <span class="title">pyshorteners</span>
                         <span class="description">Python lib to wrapper shorteners APIs</span>
                     </a>


### PR DESCRIPTION
This url is no longer pointing to the correct destination. While fixing another project called [UrlShortener](https://github.com/JavaVista/UrlShortener) I found the issue with your personal website.  

Happy Hacktoberfest!